### PR TITLE
perf(benchmarks): add IPFS & Private benchmarks

### DIFF
--- a/ipfs/fs_test.go
+++ b/ipfs/fs_test.go
@@ -1,0 +1,184 @@
+package ipfs_test
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	files "github.com/ipfs/go-ipfs-files"
+	caopts "github.com/ipfs/interface-go-ipfs-core/options"
+	corepath "github.com/ipfs/interface-go-ipfs-core/path"
+	"github.com/qri-io/wnfs-go"
+	mockipfs "github.com/qri-io/wnfs-go/ipfs/mock"
+)
+
+func BenchmarkIPFSCat10MbFile(t *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, err := mockipfs.MockMerkleDagStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := make([]byte, 1024*10)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	textFile := wnfs.NewMemfileBytes("bench.txt", data)
+	res, err := store.PutFile(textFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		f, err := store.GetFile(res.Cid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ioutil.ReadAll(f)
+	}
+}
+
+func BenchmarkIPFSWrite10MbFile(t *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	store, err := mockipfs.MockMerkleDagStore(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := make([]byte, 1024*10)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	textFile := wnfs.NewMemfileBytes("bench.txt", data)
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		store.PutFile(textFile)
+	}
+}
+
+func BenchmarkIPFSCat10MbFileSubdir(t *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, capi, err := mockipfs.MakeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := make([]byte, 1024*10)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	dir := files.NewMapDirectory(map[string]files.Node{
+		"public": files.NewMapDirectory(map[string]files.Node{
+			"subdir": files.NewMapDirectory(map[string]files.Node{
+				"bench.txt": files.NewBytesFile(data),
+			}),
+		}),
+	})
+
+	path, err := capi.Unixfs().Add(ctx, dir, caopts.Unixfs.CidVersion(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getPath := corepath.New(fmt.Sprintf("%s/public/subdir/bench.txt", path.Root()))
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		f, err := capi.Unixfs().Get(ctx, getPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ioutil.ReadAll(f.(io.Reader))
+	}
+}
+
+func BenchmarkIPFSWrite10MbFileSubdir(t *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, capi, err := mockipfs.MakeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := make([]byte, 1024*10)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	dir := files.NewMapDirectory(map[string]files.Node{
+		"public": files.NewMapDirectory(map[string]files.Node{
+			"subdir": files.NewMapDirectory(map[string]files.Node{
+				"bench.txt": files.NewBytesFile(data),
+			}),
+		}),
+	})
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		_, err := capi.Unixfs().Add(ctx, dir, caopts.Unixfs.CidVersion(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkIPFSCp10DirectoriesWithOne10MbFileEach(t *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, capi, err := mockipfs.MakeAPI(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := ioutil.TempDir("", "bench_10_single_file_directories")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	for i := 0; i < 10; i++ {
+		path := filepath.Join(dir, "copy_me", fmt.Sprintf("dir_%d", i))
+		os.MkdirAll(path, 0755)
+		path = filepath.Join(path, "bench.txt")
+
+		data := make([]byte, 1024*10)
+		if _, err := rand.Read(data); err != nil {
+			t.Fatal(err)
+		}
+		ioutil.WriteFile(path, data, os.ModePerm)
+	}
+
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialDir, err := files.NewSerialFile(dir, false, st)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.ResetTimer()
+
+	for i := 0; i < t.N; i++ {
+		if _, err := capi.Unixfs().Add(ctx, serialDir, caopts.Unixfs.CidVersion(1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// if _, err := capi.Unixfs().Open("public/copy_me/dir_0/bench.txt"); err != nil {
+	// 	t.Fatal(err)
+	// }
+}


### PR DESCRIPTION
getting an early benchmark suite up that compare raw UnixFS, WNFS public, and WNFS private. Results so far:

```
goos: darwin
goarch: amd64
pkg: github.com/qri-io/wnfs-go
cpu: Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz

BenchmarkIPFSCat10MbFile-4                             	   61572	     20811 ns/op	   49822 B/op	      42 allocs/op
BenchmarkIPFSWrite10MbFile-4                           	   30804	     47417 ns/op	   11432 B/op	     204 allocs/op
BenchmarkIPFSCat10MbFileSubdir-4                       	   36136	     30758 ns/op	   53418 B/op	     123 allocs/op
BenchmarkIPFSWrite10MbFileSubdir-4                     	   14757	     85009 ns/op	   27069 B/op	     524 allocs/op
BenchmarkIPFSCp10DirectoriesWithOne10MbFileEach-4      	     652	   1832513 ns/op	  253688 B/op	    2472 allocs/op

BenchmarkPublicCat10MbFile-4                           	   34389	     34300 ns/op	   53607 B/op	     108 allocs/op
BenchmarkPublicWrite10MbFile-4                         	    4340	    251079 ns/op	   66669 B/op	    1168 allocs/op
BenchmarkPublicCat10MbFileSubdir-4                     	   20268	     52665 ns/op	   62005 B/op	     243 allocs/op
BenchmarkPublicWrite10MbFileSubdir-4                   	    2546	    417772 ns/op	  116442 B/op	    2029 allocs/op
BenchmarkPublicCp10DirectoriesWithOne10MbFileEach-4    	  238276	      5297 ns/op	    1156 B/op	      19 allocs/op

BenchmarkPrivateCat10MbFile-4                          	   23559	     61366 ns/op	  115821 B/op	     119 allocs/op
BenchmarkPrivateWrite10MbFile-4                        	    2440	    515472 ns/op	  156549 B/op	    2287 allocs/op
BenchmarkPrivateCat10MbFileSubdir-4                    	   17660	     68230 ns/op	  124090 B/op	     187 allocs/op
BenchmarkPrivateWrite10MbFileSubdir-4                  	    1707	    755976 ns/op	  228413 B/op	    3289 allocs/op
BenchmarkPrivateCp10DirectoriesWithOne10MbFileEach-4   	     162	   6474506 ns/op	 1246602 B/op	   10928 allocs/op
```