### PR TITLE
use counters for small & medium ratchet fields

### DIFF
--- a/mmpt_test.go
+++ b/mmpt_test.go
@@ -4,15 +4,11 @@ import (
 	"context"
 	"testing"
 
-	golog "github.com/ipfs/go-log"
 	mockipfs "github.com/qri-io/wnfs-go/ipfs/mock"
 	"github.com/qri-io/wnfs-go/mdstore"
 )
 
 func TestMMPT(t *testing.T) {
-	golog.SetLogLevel("wnfs", "debug")
-	defer golog.SetLogLevel("wnfs", "info")
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/private.go
+++ b/private.go
@@ -415,7 +415,7 @@ func (pt *PrivateTree) createOrUpdateChildFile(name string, f fs.File) (PutResul
 func (pt *PrivateTree) Put() (PutResult, error) {
 	store := pt.fs.DagStore()
 
-	pt.ratchet.Advance()
+	pt.ratchet.Add1()
 	key := pt.ratchet.Key()
 	pt.info.Ratchet = pt.ratchet.Encode()
 	pt.info.Size = pt.info.Links.SizeSum()
@@ -596,7 +596,7 @@ func (pf *PrivateFile) Put() (PutResult, error) {
 	// generate a new version key by advancing the ratchet
 	// TODO(b5): what happens if anything errors after advancing the ratchet?
 	// assuming we need to make a point of throwing away the file & cleaning the MMPT
-	pf.ratchet.Advance()
+	pf.ratchet.Add1()
 	key := pf.ratchet.Key()
 
 	plainText, err := ioutil.ReadAll(pf.content)

--- a/ratchet_test.go
+++ b/ratchet_test.go
@@ -138,3 +138,35 @@ func hexMap(r *SpiralRatchet) map[string]string {
 		"smallCeil":  hex.EncodeToString(r.smallCeil[:]),
 	}
 }
+
+func BenchmarkRatchetAdvance256(b *testing.B) {
+	seed := shasumFromHex("600b56e66b7d12e08fd58544d7c811db0063d7aa467a1f6be39990fed0ca5b33")
+	for i := 0; i < b.N; i++ {
+		r := NewSpiralRatchetFromSeed(seed)
+		for i := 0; i < 255; i++ {
+			r.Advance()
+		}
+	}
+}
+
+func BenchmarkRatchetDeserializeAdvance(b *testing.B) {
+	seed := shasumFromHex("600b56e66b7d12e08fd58544d7c811db0063d7aa467a1f6be39990fed0ca5b33")
+	r := NewSpiralRatchetFromSeed(seed)
+	// advance ratchet a bunch
+	for i := 0; i < 125; i++ {
+		r.Advance()
+	}
+	// serialize to a string
+	enc := r.Encode()
+
+	// confirm ratchet will decode
+	if _, err := DecodeRatchet(enc); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		r, _ = DecodeRatchet(enc)
+		r.Advance()
+	}
+}


### PR DESCRIPTION
very nice pickup from the old approach of serializing ceiling shasums. encoded ratchets drop from 216 -> 133 bytes. That'll save 8.3Kib over 100 files.

example _old_ serialized ratchet:
```
jiAjzIubJ5xfbrA5OKv5Nd3pO-m_3ABqD1cFNf2oLviZAJ4prGVG6845XUubOkwO6vqLOoFMQ0Ohp6R4k2VeaQRtEJddpyHw6SojKe8S5uU2F6I7q_ZSsWZT6wWXdQdYwYqNp_UdIye5cS9jw1e9Yxbfc33wSTpLGOxpHezlWckjYF35WHDewaLeUePegN0ILY3e07gEHzRmfhzOikjj0Q==
```

example _new_ serialized ratchet:
```
uFwYqNp_UdIye5cS9jw1e9Yxbfc33wSTpLGOxpHezlWckAmQCeKaxlRuvOOV1LmzpMDur6izqBTENDoaekeJNlXmkAjiAjzIubJ5xfbrA5OKv5Nd3pO-m_3ABqD1cFNf2oLvg
```

Also, faster:
```
benchmark                                old ns/op     new ns/op     delta
BenchmarkRatchetAdvance256-4             376107        63957         -82.99%
BenchmarkRatchetDeserializeAdvance-4     1014          878           -13.36%

benchmark                                old allocs     new allocs     delta
BenchmarkRatchetAdvance256-4             4              3              -25.00%
BenchmarkRatchetDeserializeAdvance-4     3              3              +0.00%

benchmark                                old bytes     new bytes     delta
BenchmarkRatchetAdvance256-4             256           176           -31.25%
BenchmarkRatchetDeserializeAdvance-4     560           368           -34.29%
```