### PR TITLE
refactor(private): mdstore.Private interface & minimal Store constructor

### DIFF
--- a/base/filesystem.go
+++ b/base/filesystem.go
@@ -28,8 +28,9 @@ type MerkleDagFS interface {
 }
 
 type PrivateMerkleDagFS interface {
-	MerkleDagFS
+	Context() context.Context
 	HAMT() *hamt.Node
+	PrivateStore() mdstore.PrivateStore
 }
 
 type Node interface {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/ipfs/go-blockservice v0.1.4
 	github.com/ipfs/go-cid v0.0.7
+	github.com/ipfs/go-cidutil v0.0.2 // indirect
 	github.com/ipfs/go-datastore v0.4.5
 	github.com/ipfs/go-filestore v0.0.3
 	github.com/ipfs/go-ipfs v0.9.0

--- a/ipfs/crypto.go
+++ b/ipfs/crypto.go
@@ -40,7 +40,6 @@ func (fs *Filestore) GetEncryptedFile(root cid.Cid, key []byte) (io.ReadCloser, 
 		return nil, err
 	}
 
-	// func NewCipherFile(ctx context.Context, dserv ipld.DAGService, nd ipld.Node, auth cipher.AEAD) (files.Node, error) {
 	cf, err := cipherfile.NewCipherFile(fs.ctx, dag.NewReadOnlyDagService(ses), nd, auth)
 	if err != nil {
 		return nil, err

--- a/mdstore/store.go
+++ b/mdstore/store.go
@@ -28,9 +28,12 @@ type MerkleDagStore interface {
 	PutFile(f fs.File) (PutResult, error)
 	GetFile(root cid.Cid, path ...string) (io.ReadCloser, error)
 
+	Blockstore() blockstore.Blockstore
+}
+
+type PrivateStore interface {
 	PutEncryptedFile(f fs.File, key []byte) (PutResult, error)
 	GetEncryptedFile(root cid.Cid, key []byte) (io.ReadCloser, error)
-
 	Blockstore() blockstore.Blockstore
 }
 

--- a/private/store.go
+++ b/private/store.go
@@ -1,0 +1,130 @@
+package private
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"fmt"
+	"io"
+	"io/fs"
+
+	blockservice "github.com/ipfs/go-blockservice"
+	cid "github.com/ipfs/go-cid"
+	cidutil "github.com/ipfs/go-cidutil"
+	blockstore "github.com/ipfs/go-ipfs-blockstore"
+	ipld "github.com/ipfs/go-ipld-format"
+	dag "github.com/ipfs/go-merkledag"
+	merkledag "github.com/ipfs/go-merkledag"
+	balanced "github.com/ipfs/go-unixfs/importer/balanced"
+	ihelper "github.com/ipfs/go-unixfs/importer/helpers"
+	mh "github.com/multiformats/go-multihash"
+	cipherchunker "github.com/qri-io/wnfs-go/ipfs/cipherchunker"
+	cipherfile "github.com/qri-io/wnfs-go/ipfs/cipherfile"
+	mdstore "github.com/qri-io/wnfs-go/mdstore"
+)
+
+func newAESGCMCipher(key []byte) (cipher.AEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.NewGCM(block)
+}
+
+// warning! cipherStore doesn't pin!
+type cipherStore struct {
+	ctx context.Context
+	bs  blockstore.Blockstore
+	dag ipld.DAGService
+}
+
+var _ mdstore.PrivateStore = (*cipherStore)(nil)
+
+func NewStore(ctx context.Context, bs blockstore.Blockstore) (mdstore.PrivateStore, error) {
+	return &cipherStore{
+		ctx: ctx,
+		bs:  bs,
+		dag: merkledag.NewDAGService(blockservice.New(bs, nil)),
+	}, nil
+}
+
+func (cs *cipherStore) Blockstore() blockstore.Blockstore { return cs.bs }
+
+func (cs *cipherStore) GetEncryptedFile(root cid.Cid, key []byte) (io.ReadCloser, error) {
+	auth, err := newAESGCMCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	ses := dag.NewSession(cs.ctx, cs.dag)
+
+	nd, err := ses.Get(cs.ctx, root)
+	if err != nil {
+		return nil, err
+	}
+
+	cf, err := cipherfile.NewCipherFile(cs.ctx, dag.NewReadOnlyDagService(ses), nd, auth)
+	if err != nil {
+		return nil, err
+	}
+	return cf.(io.ReadCloser), nil
+}
+
+func (cs *cipherStore) PutEncryptedFile(f fs.File, key []byte) (mdstore.PutResult, error) {
+	fi, err := f.Stat()
+	if err != nil {
+		return mdstore.PutResult{}, err
+	}
+
+	if fi.IsDir() {
+		return mdstore.PutResult{}, fmt.Errorf("cannot write encrypted directories")
+	}
+
+	auth, err := newAESGCMCipher(key)
+	if err != nil {
+		return mdstore.PutResult{}, err
+	}
+
+	nd, err := cs.putEncryptedFile(f, auth)
+	if err != nil {
+		return mdstore.PutResult{}, err
+	}
+
+	return mdstore.PutResult{
+		Cid:  nd.Cid(),
+		Size: fi.Size(),
+	}, nil
+}
+
+func (cs *cipherStore) putEncryptedFile(f fs.File, auth cipher.AEAD) (ipld.Node, error) {
+	prefix, err := merkledag.PrefixForCidVersion(1)
+	if err != nil {
+		return nil, err
+	}
+	prefix.MhType = mh.SHA2_256
+
+	spl, err := cipherchunker.NewCipherSplitter(f, auth, 1024*1024)
+	if err != nil {
+		return nil, err
+	}
+
+	dbp := ihelper.DagBuilderParams{
+		Maxlinks:  1024,
+		RawLeaves: true,
+
+		CidBuilder: cidutil.InlineBuilder{
+			Builder: prefix,
+			Limit:   32,
+		},
+
+		Dagserv: cs.dag,
+	}
+
+	db, err := dbp.New(spl)
+	if err != nil {
+		return nil, err
+	}
+
+	return balanced.Layout(db)
+}

--- a/wnfs.go
+++ b/wnfs.go
@@ -380,7 +380,12 @@ func newEmptyRootTree(fs base.MerkleDagFS, rootKey Key) (*rootTree, error) {
 		Pretty: &base.BareTree{},
 	}
 
-	privateRoot, err := private.NewEmptyRoot(fs.Context(), fs.DagStore(), FileHierarchyNamePrivate, rootKey)
+	privStore, err := private.NewStore(fs.Context(), fs.DagStore().Blockstore())
+	if err != nil {
+		return nil, err
+	}
+
+	privateRoot, err := private.NewEmptyRoot(fs.Context(), privStore, FileHierarchyNamePrivate, rootKey)
 	if err != nil {
 		return nil, err
 	}
@@ -406,15 +411,20 @@ func newRootTreeFromCID(fs base.MerkleDagFS, id cid.Cid, rootKey Key, rootName P
 		return nil, fmt.Errorf("opening /%s tree %s:\n%w", FileHierarchyNamePublic, publicLink.Cid, err)
 	}
 
+	privStore, err := private.NewStore(fs.Context(), fs.DagStore().Blockstore())
+	if err != nil {
+		return nil, err
+	}
+
 	var privateRoot *private.Root
 
 	if hamtLink := links.Get(FileHierarchyNamePrivate); hamtLink != nil {
-		privateRoot, err = private.LoadRoot(fs.Context(), fs.DagStore(), FileHierarchyNamePrivate, hamtLink.Cid, rootKey, rootName)
+		privateRoot, err = private.LoadRoot(fs.Context(), privStore, FileHierarchyNamePrivate, hamtLink.Cid, rootKey, rootName)
 		if err != nil {
 			return nil, fmt.Errorf("opening private tree:\n%w", err)
 		}
 	} else {
-		privateRoot, err = private.NewEmptyRoot(fs.Context(), fs.DagStore(), FileHierarchyNamePrivate, rootKey)
+		privateRoot, err = private.NewEmptyRoot(fs.Context(), privStore, FileHierarchyNamePrivate, rootKey)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
now it's possible to create a private.RootTree backed by a store that only requires a blockstore, not a full IPFS node