### PR TITLE
perf(ratchet): switch to sha3

### DIFF
--- a/cmd/ipfs/fs_test.go
+++ b/cmd/ipfs/fs_test.go
@@ -38,7 +38,7 @@ func BenchmarkIPFSCat10MbFile(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		f, err := store.GetFile(res.Cid)
+		f, err := store.GetFile(ctx, res.Cid)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/ipfs/mock/mock.go
+++ b/cmd/ipfs/mock/mock.go
@@ -51,7 +51,7 @@ func MakeAPISwarm(ctx context.Context, fullIdentity bool, n int) ([]*core.IpfsNo
 				return nil, nil, err
 			}
 
-			kbytes, err := sk.Bytes()
+			kbytes, err := sk.Raw()
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
faster.

```
$ benchcmp master.txt sha3.txt
benchmark                                                old ns/op      new ns/op      delta
BenchmarkIPFSCat10MbFile-4                               23847          25574          +7.24%
BenchmarkIPFSWrite10MbFile-4                             57115          52016          -8.93%
BenchmarkIPFSCat10MbFileSubdir-4                         62323          59235          -4.95%
BenchmarkIPFSWrite10MbFileSubdir-4                       121900         114753         -5.86%
BenchmarkIPFSCp10DirectoriesWithOne10MbFileEach-4        2504300        2151781        -14.08%
BenchmarkPublicCat10MbFile-4                             160940         139502         -13.32%
BenchmarkPublicWrite10MbFile-4                           467663096      413785247      -11.52%
BenchmarkPublicCat10MbFileSubdir-4                       444089         281957         -36.51%
BenchmarkPublicWrite10MbFileSubdir-4                     673108614      726374279      +7.91%
BenchmarkPublicCp10DirectoriesWithOne10MbFileEach-4      6692854643     6931491407     +3.57%
BenchmarkPrivateCat10MbFile-4                            554663         122874         -77.85%
BenchmarkPrivateWrite10MbFile-4                          321439286      296391631      -7.79%
BenchmarkPrivateCat10MbFileSubdir-4                      1106848        178223         -83.90%
BenchmarkPrivateWrite10MbFileSubdir-4                    414538861      381436433      -7.99%
BenchmarkPrivateCp10DirectoriesWithOne10MbFileEach-4     3189553722     2754943154     -13.63%

benchmark                                                old allocs     new allocs     delta
BenchmarkIPFSCat10MbFile-4                               53             53             +0.00%
BenchmarkIPFSWrite10MbFile-4                             258            258            +0.00%
BenchmarkIPFSCat10MbFileSubdir-4                         324            324            +0.00%
BenchmarkIPFSWrite10MbFileSubdir-4                       663            663            +0.00%
BenchmarkIPFSCp10DirectoriesWithOne10MbFileEach-4        3017           3017           +0.00%
BenchmarkPublicCat10MbFile-4                             113            113            +0.00%
BenchmarkPublicWrite10MbFile-4                           968            940            -2.89%
BenchmarkPublicCat10MbFileSubdir-4                       268            268            +0.00%
BenchmarkPublicWrite10MbFileSubdir-4                     1503           1514           +0.73%
BenchmarkPublicCp10DirectoriesWithOne10MbFileEach-4      14672          14831          +1.08%
BenchmarkPrivateCat10MbFile-4                            101            101            +0.00%
BenchmarkPrivateWrite10MbFile-4                          860            895            +4.07%
BenchmarkPrivateCat10MbFileSubdir-4                      165            165            +0.00%
BenchmarkPrivateWrite10MbFileSubdir-4                    1176           1242           +5.61%
BenchmarkPrivateCp10DirectoriesWithOne10MbFileEach-4     10362          11235          +8.43%

benchmark                                                old bytes     new bytes     delta
BenchmarkIPFSCat10MbFile-4                               50278         50289         +0.02%
BenchmarkIPFSWrite10MbFile-4                             18063         18060         -0.02%
BenchmarkIPFSCat10MbFileSubdir-4                         66160         66158         -0.00%
BenchmarkIPFSWrite10MbFileSubdir-4                       53960         53987         +0.05%
BenchmarkIPFSCp10DirectoriesWithOne10MbFileEach-4        350421        347952        -0.70%
BenchmarkPublicCat10MbFile-4                             97473         97484         +0.01%
BenchmarkPublicWrite10MbFile-4                           270720        180541        -33.31%
BenchmarkPublicCat10MbFileSubdir-4                       110801        110787        -0.01%
BenchmarkPublicWrite10MbFileSubdir-4                     152432        153520        +0.71%
BenchmarkPublicCp10DirectoriesWithOne10MbFileEach-4      2335648       2086472       -10.67%
BenchmarkPrivateCat10MbFile-4                            86010         85959         -0.06%
BenchmarkPrivateWrite10MbFile-4                          1470024       1411742       -3.96%
BenchmarkPrivateCat10MbFileSubdir-4                      95656         95623         -0.03%
BenchmarkPrivateWrite10MbFileSubdir-4                    2141714       2242216       +4.69%
BenchmarkPrivateCp10DirectoriesWithOne10MbFileEach-4     27745320      27145656      -2.16%
```